### PR TITLE
Adding chart examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3897,6 +3897,32 @@
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
+    "chart.js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
+      "integrity": "sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -14578,6 +14604,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-chartjs-2": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.9.0.tgz",
+      "integrity": "sha512-IYwqUUnQRAJ9SNA978vxulHJTcUFTJk2LDVfbAyk0TnJFZZG7+6U/2flsE4MCw6WCbBjTTypy8T82Ch7XrPtRw==",
+      "requires": {
+        "lodash": "^4.17.4",
+        "prop-types": "^15.5.8"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@google-cloud/secret-manager": "2.1.0",
     "@material-ui/core": "4.9.7",
+    "chart.js": "^2.9.3",
     "dotenv": "8.2.0",
     "echart": "0.1.3",
     "echarts": "4.7.0",
@@ -23,6 +24,7 @@
     "gatsby-transformer-sharp": "2.4.3",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
+    "react-chartjs-2": "^2.9.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1"
   },

--- a/src/pages/charts.js
+++ b/src/pages/charts.js
@@ -1,0 +1,154 @@
+import React from "react"
+import { Link } from "gatsby"
+
+import Layout from "../components/layout"
+import CustomCard from "../components/custom-card"
+import SEO from "../components/seo"
+import Container from "@material-ui/core/Container"
+
+import {Doughnut} from 'react-chartjs-2';
+import {Pie} from 'react-chartjs-2';
+import {Bar} from 'react-chartjs-2';
+import {HorizontalBar} from 'react-chartjs-2';
+
+const chartColors = ["#00695c", "#003c8f", '#ad2200','#36A2EB','#FFCE56']
+
+const genderData = {
+  labels: ["Male", "Female"],
+  datasets: [
+    {
+      data: [4, 2],
+      backgroundColor: chartColors,
+      hoverBackgroundColor: chartColors,
+    },
+  ],
+}
+
+const casesData = {
+    labels: ["Infected", "Recovered", "Deaths"],
+    datasets: [
+      {
+        data: [1252265, 258495, 68148],
+        backgroundColor: chartColors,
+        hoverBackgroundColor: chartColors,
+      },
+    ],
+  }
+
+const ageData = {
+    labels: ["Infant", "Child", "Adult", "Senior"],
+    datasets: [
+      {
+        data: [1, 1, 5, 1],
+        backgroundColor: chartColors,
+        hoverBackgroundColor: chartColors,
+      },
+    ],
+  }
+
+  const timelineData = {
+    labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+    datasets: [
+      {
+        label: 'Reported cases',
+        backgroundColor: 'rgba(255,99,132,0.2)',
+        borderColor: 'rgba(255,99,132,1)',
+        borderWidth: 1,
+        hoverBackgroundColor: 'rgba(255,99,132,0.4)',
+        hoverBorderColor: 'rgba(255,99,132,1)',
+        data: [0, 0, 1, 3, 0, 0, 0]
+      }
+    ]
+  };
+
+  const symptomsData = {
+    labels: ['Fever', 'Cough', 'Sore Throat', 'Headaches', 'Difficulty Breathing', 'Muscle Pain', 'Tiredness'],
+    datasets: [
+      {
+        label: 'Cases reported',
+        backgroundColor: 'rgba(255,99,132,0.2)',
+        borderColor: 'rgba(255,99,132,1)',
+        borderWidth: 1,
+        hoverBackgroundColor: 'rgba(255,99,132,0.4)',
+        hoverBorderColor: 'rgba(255,99,132,1)',
+        data: [20, 10, 1, 30, 10, 3, 11]
+      }
+    ]
+  };
+
+const Charts = () => (
+  <Layout>
+    <SEO title="Page two" />
+    <h1>Charts examples</h1>
+    <Container maxWidth="sm">
+    
+    <CustomCard title={"Global caces distribution"}>        
+          <Doughnut
+            data={casesData}
+            options={{
+              legend: {
+                display: true,
+                align: "center",
+                position: "bottom",
+              },
+            }}
+          />        
+      </CustomCard>
+
+      <CustomCard title={"Gender distribution"}>        
+          <Doughnut
+            data={genderData}
+            options={{
+              legend: {
+                display: true,
+                align: "center",
+                position: "bottom",
+              },
+            }}
+          />        
+      </CustomCard>
+
+      <CustomCard title={"Age distribution"}>        
+          <Pie
+            data={ageData}
+            options={{
+              legend: {
+                display: true,
+                align: "center",
+                position: "bottom",
+              },
+            }}
+          />        
+      </CustomCard>
+
+      <CustomCard title={"Timeline distribution"}>        
+          <Bar
+            data={timelineData}
+            options={{
+              legend: {
+                display: true,
+                align: "center",
+                position: "bottom",
+              },
+            }}
+          />        
+      </CustomCard>
+
+      <CustomCard title={"Symptoms distribution"}>          
+        <HorizontalBar
+         data={symptomsData} 
+         options={{
+            legend: {
+              display: true,
+              align: "center",
+              position: "bottom",
+            },
+          }}
+         />  
+      </CustomCard>
+    </Container>
+    <Link to="/">Go back to the homepage</Link>
+  </Layout>
+)
+
+export default Charts


### PR DESCRIPTION
Added `react-chartjs-2` along with some examples .
https://www.npmjs.com/package/react-chartjs-2
<img width="293" alt="Screenshot 2020-04-05 at 23 08 52" src="https://user-images.githubusercontent.com/502798/78510048-c27b1c00-7792-11ea-9ca1-02395b618f73.png">
